### PR TITLE
fix(bot): always prompt subgroup after group selection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "ruzbot"
-version = "2.0.0"
+version = "2.0.1"
 description = "Telegram-бот для расписания (RUZ)"
 requires-python = ">=3.10"
 dependencies = [

--- a/src/ruzbot/callbacks.py
+++ b/src/ruzbot/callbacks.py
@@ -87,7 +87,7 @@ async def textCallbackHandler(callback, bot: AsyncTeleBot):
             prev = u.get("subgroup")
             logger.debug(f"Sub-group set/update: {sub_group_number} for user_id={uid}")
             await commands.updateUserSubGroup(uid, sub_group_number)
-            msg = "Регистрация завершена." if prev is None else "Подгруппа обновлена."
+            msg = "Подгруппа установлена." if prev is None else "Подгруппа обновлена."
             message = await bot.reply_to(callback, msg)
             await commands.sendProfileCommand(bot, message, user_id=uid)
 
@@ -137,9 +137,9 @@ async def buttonsCallback(callback, bot: AsyncTeleBot):
             logger.debug(
                 f"Button 'setGroup' pressed with group_oid={group_oid}, label={group_label!r}"
             )
-            needs_subgroup = await commands.setGroup(bot, callback, group_oid, group_label)
-            if needs_subgroup:
-                await commands.setSubGroupCommand(bot, callback.message, user_id=uid)
+            await commands.setGroup(bot, callback, group_oid, group_label)
+            await bot.answer_callback_query(callback.id)
+            await commands.setSubGroupCommand(bot, callback.message, user_id=uid)
 
         case ["searchTeacher"]:
             # await search_handlers.search_teacher_list_command(bot, callback.message, 0, user_id=uid)

--- a/src/ruzbot/commands.py
+++ b/src/ruzbot/commands.py
@@ -283,7 +283,7 @@ async def setGroupCommand(bot, message, *, user_id: int):
 async def setSubGroupCommand(bot, message, *, user_id: int):
     logger.info(f"setSubGroupCommand called: user={user_id}")
     reply_message = (
-        "Чтобы завершить регистрацию, введите одну цифру подгруппы: 0, 1 или 2.\n"
+        "Введите одну цифру подгруппы: 0, 1 или 2.\n"
         "Если номер не является числом, введите 0."
     )
     await bot.reply_to(message, reply_message)
@@ -335,10 +335,11 @@ async def sendProfileCommand(bot, message, *, user_id: int):
     logger.info(f"sendProfileCommand completed: user={user_id}")
 
 
-async def setGroup(bot, callback, group_oid: int, group_label: str) -> bool:
+async def setGroup(bot, callback, group_oid: int, group_label: str) -> None:
     """
-    Новый пользователь: создаётся на сервере с ``subgroup=null``; подгруппа задаётся отдельным шагом.
-    Существующий: обновляем группу. Возвращает True, если нужно запросить подгруппу (первичная регистрация).
+    Создаёт или обновляет группу на сервере. Дальше бот просит подгруппу (0/1/2);
+    при смене группы у существующего пользователя подгруппа на API не обнуляется —
+    бэкенд не допускает subgroup=null при заданном group_oid.
     """
     user_id = callback.from_user.id
     logger.info(f"setGroup called: user_id={user_id}, group_oid={group_oid}, group_label={group_label!r}")
@@ -365,7 +366,7 @@ async def setGroup(bot, callback, group_oid: int, group_label: str) -> bool:
             )
             await client.users.create_user(payload)
             logger.info(f"User {user_id} created with group_oid={group_oid}, subgroup=null")
-            return True
+            return
         upd = UserUpdate(
             group_oid=group_oid,
             group_guid=hit["guid"] if hit else None,
@@ -374,7 +375,6 @@ async def setGroup(bot, callback, group_oid: int, group_label: str) -> bool:
         )
         await client.users.update_user(user_id, upd)
         logger.info(f"User {user_id} updated group_oid={group_oid}")
-        return False
 
 
 async def updateUserSubGroup(user_id: int, sub_group: int) -> None:


### PR DESCRIPTION
## Summary
- always prompt for subgroup immediately after a group is selected
- simplify the group-selection flow so the callback handler consistently advances registration
- bump the package version to `2.0.1`

## Behavioral change
Before this change, the bot only prompted for subgroup selection during initial registration. After this change, selecting a group always leads into the subgroup step, so users can immediately confirm or update subgroup after changing groups.

The user-facing copy was also adjusted to match the new flow:
- subgroup prompt no longer refers only to finishing registration
- initial subgroup confirmation now says `Подгруппа установлена.`

## Tests
- `python -m compileall src`

## Notes
- The repository does not currently include an automated test suite, so validation for this PR is limited to bytecode compilation.